### PR TITLE
Travis: Build with 1.6, run gofmt, go vet, go test -race checks.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,19 @@
+sudo: false
 language: go
-
 go:
- - tip
-
+  - 1.6.2
+  - tip
+matrix:
+  allow_failures:
+    - go: tip
+  fast_finish: true
 install:
   - go get github.com/mattn/goveralls
-  - go get github.com/google/go-querystring/query
-
-before_script:
-  - export PATH=$HOME/gopath/bin:$PATH
-
 script:
+  - go get -t -v ./...
+  - diff -u <(echo -n) <(gofmt -d -s .)
+  - go tool vet .
+  - go test -v -race ./...
   - go test -covermode=count -coverprofile=profile.cov ./asana
-
 after_success:
   - goveralls -coverprofile=profile.cov -service=travis-ci


### PR DESCRIPTION
This change adds extra checks to Travis CI and makes it more similar to https://github.com/google/go-github/blob/master/.travis.yml.
